### PR TITLE
Header comments, cmake error messages added. include_directories removed

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,90 @@
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+# AccessModifierOffset: -2
+# AlignAfterOpenBracket: Align
+# AlignConsecutiveAssignments: false
+# AlignConsecutiveDeclarations: false
+# AlignEscapedNewlinesLeft: false
+# AlignOperands:   true
+# AlignTrailingComments: true
+# AllowAllParametersOfDeclarationOnNextLine: true
+# AllowShortBlocksOnASingleLine: false
+# AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: false
+# AllowShortIfStatementsOnASingleLine: false
+# AllowShortLoopsOnASingleLine: false
+# AlwaysBreakAfterDefinitionReturnType: None
+# AlwaysBreakAfterReturnType: None
+# AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+# BinPackArguments: true
+# BinPackParameters: true
+BraceWrapping:   
+  AfterClass:      true
+  AfterControlStatement: true
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: false
+  AfterStruct:     true
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      true
+  IndentBraces:    false
+#BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializersBeforeComma: true
+ColumnLimit:     200
+# CommentPragmas:  '^ IWYU pragma:'
+# ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 0
+# ContinuationIndentWidth: 4
+# Cpp11BracedListStyle: true
+# DerivePointerAlignment: false
+# DisableFormat:   false
+# ExperimentalAutoDetectBinPacking: false
+# ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+# IncludeCategories: 
+#   - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+#     Priority:        2
+#   - Regex:           '^(<|"(gtest|isl|json)/)'
+#     Priority:        3
+#   - Regex:           '.*'
+#     Priority:        1
+# IndentCaseLabels: false
+# IndentWidth:     2
+# IndentWrappedFunctionNames: false
+# KeepEmptyLinesAtTheStartOfBlocks: true
+# MacroBlockBegin: ''
+# MacroBlockEnd:   ''
+# MaxEmptyLinesToKeep: 1
+# NamespaceIndentation: None
+# ObjCBlockIndentWidth: 2
+# ObjCSpaceAfterProperty: false
+# ObjCSpaceBeforeProtocolList: true
+# PenaltyBreakBeforeFirstCallParameter: 19
+# PenaltyBreakComment: 300
+# PenaltyBreakFirstLessLess: 120
+# PenaltyBreakString: 1000
+# PenaltyExcessCharacter: 1000000
+# PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+# ReflowComments:  true
+# SortIncludes:    true
+# SpaceAfterCStyleCast: false
+# SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: Never
+# SpaceInEmptyParentheses: false
+# SpacesBeforeTrailingComments: 1
+# SpacesInAngles:  false
+# SpacesInContainerLiterals: true
+# SpacesInCStyleCastParentheses: false
+# SpacesInParentheses: false
+# SpacesInSquareBrackets: false
+# Standard:        Cpp11
+TabWidth:        2
+UseTab:          Never
+...
+

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,31 @@
+Checks:          '-*,modernize-use-nullptr,modernize-deprecated-headers,modernize-shrink-to-fit,modernize-use-bool-literals,modernize-use-default-member-init,modernize-use-equals-default,modernize-use-equals-delete,modernize-use-override,modernize-use-equals-default,readability-avoid-const-params-in-decls,readability-braces-around-statements,readability-container-size-empty,readability-delete-null-pointer,readability-else-after-return,readability-implicit-bool-conversion,readability-redundant-control-flow,readability-redundant-declaration,readability-redundant-function-ptr-dereference,readability-redundant-member-init,readability-redundant-smartptr-get,readability-redundant-string-cstr,readability-redundant-string-init,readability-simplify-boolean-expr,readability-simplify-subscript-expr,readability-static-accessed-through-instance,readability-static-definition-in-anonymous-namespace,readability-string-compare'
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+FormatStyle:     file
+User:            mjackson
+CheckOptions:
+  - key:             google-readability-braces-around-statements.ShortStatementLines
+    value:           '1'
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             google-readability-namespace-comments.ShortNamespaceLines
+    value:           '10'
+  - key:             google-readability-namespace-comments.SpacesBeforeComments
+    value:           '2'
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-default-member-init.IgnoreMacros
+    value:           '1'
+  - key:             modernize-use-default-member-init.UseAssignment
+    value:           '1'
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,10 +59,9 @@ endif()
 string(CONCAT SHT_FILE_VERS "v" ${SHT_GIT_HASH}) # hash is only 7 characters, make 8 by prepending with v
 string(LENGTH ${SHT_FILE_VERS} STR_LEN)
 if(NOT 8 EQUAL ${STR_LEN})
-	message(FATAL_ERROR "version string must be 8 characters long")
+	message(FATAL_ERROR "Git Hash must be 8 characters long. Computed was: ${SHT_FILE_VERS}")
 endif()
 
 # configure file using version string and include 
 configure_file(${SHTfile_SOURCE_DIR}/sht_file.hpp.in ${SHTfile_BINARY_DIR}/sht_file.hpp)
-include_directories(${CMAKE_CURRENT_BINARY_DIR}) # output of configure_file is relative to this
 

--- a/sht_file.hpp.in
+++ b/sht_file.hpp.in
@@ -32,6 +32,15 @@
  *                                                                                 *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
+/**
+ * This file is configured from the following template file:
+ * @CMAKE_CURRENT_SOURCE_DIR@/sht_file.hpp.in
+ * 
+ * To fix compile errors in this file you need to edit the original file and NOT
+ * this file.
+ */
+
+
 #ifndef _SHT_FILE_H_
 #define _SHT_FILE_H_
 


### PR DESCRIPTION
* Comment added to main source file that shows the absolute path to where the file came from,
i.e,, what was the path of the template used to generate the file.
* Create a more explicit error message if the Git hash is not 8 characters.
* remote the use of include_directories as this is not idiomatic with mordern CMake standards.

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>